### PR TITLE
Upgrade deps to EverShop v2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
   "license": "ISC",
   "description": "",
   "dependencies": {
-    "@evershop/evershop": "1.2.2",
-    "@evershop/s3_file_storage": "1.2.0",
+    "@evershop/evershop": "2.1.0",
+    "@evershop/s3_file_storage": "2.1.0",
     "nodemailer": "^6.9.15"
   },
   "devDependencies": {


### PR DESCRIPTION
Closes #6
Part of #5

Changes:
- Bump @evershop/evershop to 2.1.0
- Bump @evershop/s3_file_storage to 2.1.0

Notes:
- On Node v24, evershop CLI errors with pg named export Pool.
- Node version pinning/doc will be addressed in #11.
