### PR TITLE
Fix contact-email middleware for EverShop v2

### DIFF
--- a/extensions/contact/api/contactMail/[bodyparser]mailsender.js
+++ b/extensions/contact/api/contactMail/[bodyparser]mailsender.js
@@ -1,6 +1,6 @@
 const nodemailer = require('nodemailer');
 
-module.exports = async (req, res, delegate, next) => {
+module.exports = async (req, res, next) => {
 	const { name, phone, email, inquiry } = req.body;
 	// Simple validation
 	if (!email || !inquiry) {

--- a/extensions/contact/api/contactMail/bodyparser.js
+++ b/extensions/contact/api/contactMail/bodyparser.js
@@ -1,5 +1,5 @@
 const bodyParser = require('body-parser');
 
-module.exports =(request, response, delegate, next) => {
+module.exports = (request, response, next) => {
 	bodyParser.json({inflate: false})(request, response, next);
 };


### PR DESCRIPTION
Closes #7
Part of #5

EverShop v2 removed the `delegate` argument from middleware handlers.
This updates the contact-email extension middlewares to the new signature.

Files:
- extensions/contact/api/contactMail/bodyparser.js
- extensions/contact/api/contactMail/[bodyparser]mailsender.js
