### PR TITLE
Patch postgres-query-builder pg import for EverShop v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "dev": "evershop dev",
     "user:create": "evershop user:create",
     "user:changePassword": "evershop user:changePassword",
+    "postinstall": "patch-package",
     "test": "vitest run"
   },
   "author": "Han Li",
@@ -24,6 +25,7 @@
     "nodemailer": "^6.9.15"
   },
   "devDependencies": {
+    "patch-package": "^8.0.1",
     "vitest": "^1.6.1"
   }
 }

--- a/patches/@evershop+postgres-query-builder+2.0.1.patch
+++ b/patches/@evershop+postgres-query-builder+2.0.1.patch
@@ -1,0 +1,11 @@
+diff --git a/node_modules/@evershop/postgres-query-builder/dist/index.js b/node_modules/@evershop/postgres-query-builder/dist/index.js
+index a21bece..1fce6ff 100644
+--- a/node_modules/@evershop/postgres-query-builder/dist/index.js
++++ b/node_modules/@evershop/postgres-query-builder/dist/index.js
+@@ -1,4 +1,5 @@
+-import { Pool } from 'pg';
++import pg from 'pg';
++const { Pool } = pg;
+ import uniqid from 'uniqid';
+ import { fieldResolve } from './fieldResolve.js';
+ import { isValueASQL } from './isValueASQL.js';


### PR DESCRIPTION
Closes #15
Part of #5

Problem:
- EverShop v2.1.0 fails during install/start due to `import { Pool } from 'pg'` in @evershop/postgres-query-builder (pg is CommonJS).

Fix:
- Add patch-package + postinstall hook
- Patch @evershop/postgres-query-builder@2.0.1 to use `import pg from 'pg'; const { Pool } = pg;`

Notes:
- Remove this patch once upstream publishes a fixed postgres-query-builder release.
