### PR TITLE
Docs: env vars for S3 + contact email

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,24 @@
 
 This project targets Node.js LTS (see `.nvmrc`). EverShop v2.x is known to fail on Node v24 in this environment.
 
+## Environment variables
+
+### S3 storage (`@evershop/s3_file_storage`)
+
+Set these in `.env`:
+
+- `AWS_ACCESS_KEY_ID`
+- `AWS_SECRET_ACCESS_KEY`
+- `AWS_REGION`
+- `AWS_BUCKET_NAME`
+
+### Contact form email (custom extension)
+
+Set these in `.env`:
+
+- `SMTP_USER`
+- `SMTP_PASSWORD`
+
 ## DB
 
 - connect as root: `sudo -u postgres psql`


### PR DESCRIPTION
Closes #9
Part of #5

Adds README docs for required .env vars:
- AWS_* vars needed by @evershop/s3_file_storage
- SMTP_* vars used by the custom contact-email extension
