### PR TITLE
Build: compile s3_file_storage before evershop build

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,10 @@
   "main": "index.js",
   "scripts": {
     "setup": "evershop install",
-    "build": "evershop build",
+    "build": "npm run build:extensions && evershop build",
+    "build:extensions": "npm run build:s3_file_storage && npm run build:contact_extension",
+    "build:s3_file_storage": "npm --prefix node_modules/@evershop/s3_file_storage run compile",
+    "build:contact_extension": "rm -rf extensions/contact/dist && mkdir -p extensions/contact/dist && cp -R extensions/contact/api extensions/contact/pages extensions/contact/tests extensions/contact/dist/",
     "start": "evershop start",
     "start:debug": "evershop start --debug",
     "dev": "evershop dev",
@@ -24,6 +27,9 @@
     "nodemailer": "^6.9.15"
   },
   "devDependencies": {
-    "vitest": "^1.6.1"
+    "@types/express": "^4.17.23",
+    "@types/multer": "^1.4.13",
+    "vitest": "^1.6.1",
+    "typescript": "^5.9.2"
   }
 }


### PR DESCRIPTION
Closes #20
Part of #5

EverShop v2 requires enabled extensions to have dist/.
This adds an extension pre-build step to compile @evershop/s3_file_storage (TypeScript) before running `evershop build`.

Notes:
- Adds TypeScript + required Express/Multer type deps for compilation.
- Theme + local extension src/dist restructuring is handled separately.
