### PR TITLE
Patch EverShop core pg import

### DIFF
--- a/patches/@evershop+evershop+2.1.0.patch
+++ b/patches/@evershop+evershop+2.1.0.patch
@@ -1,0 +1,26 @@
+diff --git a/node_modules/@evershop/evershop/dist/bin/install/index.js b/node_modules/@evershop/evershop/dist/bin/install/index.js
+index 9028e40..4ee3e0b 100644
+--- a/node_modules/@evershop/evershop/dist/bin/install/index.js
++++ b/node_modules/@evershop/evershop/dist/bin/install/index.js
+@@ -5,7 +5,8 @@ import boxen from 'boxen';
+ import enquirer from 'enquirer';
+ import kleur from 'kleur';
+ import ora from 'ora';
+-import { Pool } from 'pg';
++import pg from 'pg';
++const { Pool } = pg;
+ import { CONSTANTS } from '../../lib/helpers.js';
+ import { error, success } from '../../lib/log/logger.js';
+ import { hashPassword } from '../../lib/util/passwordHelper.js';
+diff --git a/node_modules/@evershop/evershop/dist/lib/postgres/connection.js b/node_modules/@evershop/evershop/dist/lib/postgres/connection.js
+index 6c3209f..b1c3f04 100644
+--- a/node_modules/@evershop/evershop/dist/lib/postgres/connection.js
++++ b/node_modules/@evershop/evershop/dist/lib/postgres/connection.js
+@@ -1,5 +1,6 @@
+ import fs from 'fs';
+-import { Pool } from 'pg';
++import pg from 'pg';
++const { Pool } = pg;
+ import { getConfig } from '../util/getConfig.js';
+ // Use env for the database connection, maintain the backward compatibility
+ const connectionSetting = {


### PR DESCRIPTION
Closes #19
Part of #5

Fixes EverShop core ESM/CJS interop with pg by patching `import { Pool } from 'pg'` to default import + destructure.

This is a patch-package workaround until upstream publishes a fixed @evershop/evershop release.
