### PR TITLE
Add production config with shop.homeUrl

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -1,0 +1,5 @@
+{
+  "shop": {
+    "homeUrl": "https://goodtrendpromos.com"
+  }
+}


### PR DESCRIPTION
## Problem

After deploying EverShop 2.1.1 to Azure, the admin login (and other routes) failed because all generated URLs pointed to \`http://localhost:3000\` instead of the production domain.

## Root Cause

EverShop's \`getBaseUrl()\` uses the \`shop.homeUrl\` config key and defaults to \`http://localhost:{port}\` when not configured. This caused login form actions, account links, and other URLs to point to localhost.

## Fix

Add \`config/production.json\` with \`shop.homeUrl\` set to \`https://goodtrendpromos.com\`. This file is loaded by \`node-config\` when \`NODE_ENV=production\` (set by \`evershop start\`).