### PR TITLE
Add start:local script and document local dev options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .log
 node_modules
 .env
+config/local*.json
 extensions/**/dist
 themes/**/dist
 extensions/**/dist

--- a/README.md
+++ b/README.md
@@ -31,6 +31,32 @@ Set these in `.env`:
   - Confirm product images load from S3
   - Submit `/contact` form and confirm email is sent
 
+## Local preview of production build
+
+`evershop start` sets `NODE_ENV=production`, which loads `config/production.json` containing the prod `shop.homeUrl` (`https://goodtrendpromos.com`). This causes admin and other URLs to point to the prod domain instead of localhost. Two options to override locally:
+
+### Option 1: `start:local` script (recommended)
+
+```bash
+npm run start:local
+```
+
+Uses `NODE_CONFIG` env var to override `shop.homeUrl` back to `http://localhost:3000`.
+
+### Option 2: `local-production.json` file
+
+Create `config/local-production.json` (gitignored):
+
+```json
+{
+  "shop": {
+    "homeUrl": "http://localhost:3000"
+  }
+}
+```
+
+Then run `npm start` as usual. `node-config` loads `local-production.json` after `production.json`, overriding the prod URL.
+
 ## DB
 
 - connect as root: `sudo -u postgres psql`

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build:contact_extension": "rm -rf extensions/contact/dist && cd extensions/contact/src && npx swc . -d ../dist --config-file ../.swcrc --copy-files",
     "build:theme:eve": "rm -rf themes/eve/dist && cd themes/eve/src && npx swc . -d ../dist --config-file ../.swcrc --copy-files",
     "start": "evershop start",
+    "start:local": "NODE_CONFIG='{\"shop\":{\"homeUrl\":\"http://localhost:3000\"}}' evershop start",
     "start:debug": "evershop start --debug",
     "predev": "rm -rf themes/eve/dist extensions/contact/dist",
     "dev": "evershop dev",


### PR DESCRIPTION
## Problem

\`evershop start\` sets \`NODE_ENV=production\`, which loads \`config/production.json\` with \`shop.homeUrl\` pointing to \`https://goodtrendpromos.com\`. When previewing the production build locally, admin and other URLs point to the prod domain instead of localhost.

## Changes

- **\`start:local\` script** in \`package.json\`: Uses \`NODE_CONFIG\` env var to override \`shop.homeUrl\` to \`http://localhost:3000\`
- **\`.gitignore\`**: Added \`config/local*.json\` for the file-based override approach
- **\`README.md\`**: Documented both approaches (script and local-production.json)