### PR TITLE
Hide storefront login icon

### DIFF
--- a/themes/eve/src/css/global.scss
+++ b/themes/eve/src/css/global.scss
@@ -12,3 +12,7 @@ html body main.content {
 .search__box {
   align-self: center;
 }
+
+.header .customer-icon {
+  display: none !important;
+}


### PR DESCRIPTION
## Summary
- hide the storefront account/login icon in the header
- keep the cart icon visible
- scope the change to theme CSS only

## Testing
- npm run build:theme:eve