### PR TITLE
chore: upgrade EverShop to 2.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@evershop/evershop": "2.1.1",
+        "@evershop/evershop": "2.1.2",
         "@evershop/s3_file_storage": "2.1.1",
         "nodemailer": "^6.9.15"
       },
@@ -2351,9 +2351,9 @@
       "license": "MIT"
     },
     "node_modules/@evershop/evershop": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@evershop/evershop/-/evershop-2.1.1.tgz",
-      "integrity": "sha512-rRYZs7qNYTCnXpsHUOanMmSecv3r8Sua31CLgHqSXSpAYPkXw77zAXaCC3qMjsmWvgc2ZywmWhERnsFtxMxoGQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@evershop/evershop/-/evershop-2.1.2.tgz",
+      "integrity": "sha512-WU4jG20EqqF77gv/y8X9rkmg1ToJTPCogRH5w4Qax8hu1dSdyRhqcYsFcvWWQnojespd7r/IHyeuAgGEkFqxwQ==",
       "license": "GNU GENERAL PUBLIC LICENSE 3.0",
       "dependencies": {
         "@base-ui/react": "^1.1.0",
@@ -2368,13 +2368,14 @@
         "@editorjs/raw": "^2.5.0",
         "@evershop/editorjs-image": "^1.1.0",
         "@evershop/postgres-query-builder": "^2.0.1",
+        "@evershop/sonner": "^2.0.7",
         "@graphql-tools/load-files": "^6.6.1",
         "@graphql-tools/merge": "^8.4.2",
         "@graphql-tools/schema": "^9.0.19",
         "@hapi/topo": "^5.0.0",
         "@pmmmwh/react-refresh-webpack-plugin": "^0.6.0",
-        "@stripe/react-stripe-js": "^1.5.0",
-        "@stripe/stripe-js": "^1.18.0",
+        "@stripe/react-stripe-js": "^3.10.0",
+        "@stripe/stripe-js": "^5.10.0",
         "@swc/cli": "^0.7.7",
         "@swc/core": "^1.11.29",
         "@tailwindcss/postcss": "^4.1.18",
@@ -2408,7 +2409,7 @@
         "graphql": "^16.6.0",
         "graphql-tag": "^2.12.6",
         "graphql-type-json": "^0.3.2",
-        "handlebars": "^4.7.8",
+        "handlebars": "^4.7.9",
         "html-entities": "^2.3.3",
         "html-webpack-plugin": "^5.5.0",
         "immer": "^10.1.1",
@@ -2420,8 +2421,8 @@
         "lucide-react": "^0.562.0",
         "luxon": "^2.0.2",
         "mini-css-extract-plugin": "^2.6.1",
-        "minimatch": "^10.1.1",
-        "multer": "^2.0.1",
+        "minimatch": "^10.2.3",
+        "multer": "^2.1.1",
         "node-cron": "^3.0.3",
         "ora": "^5.4.1",
         "pg": "^8.16.3",
@@ -2438,14 +2439,14 @@
         "react-toastify": "^6.2.0",
         "recharts": "^2.0.9",
         "sanitize-html": "^2.17.0",
-        "sass": "^1.53.0",
+        "sass": "^1.98.0",
         "sass-loader": "^13.0.2",
         "semver": "^7.6.3",
         "serve-static": "^1.15.0",
         "session-file-store": "^1.5.0",
         "sharp": "^0.33.5",
         "slick-carousel": "^1.8.1",
-        "stripe": "^8.176.0",
+        "stripe": "^21.0.1",
         "style-loader": "^3.3.1",
         "swc-minify-webpack-plugin": "^2.1.3",
         "tailwind-merge": "^3.4.0",
@@ -2461,7 +2462,7 @@
         "webpackbar": "^5.0.2",
         "winston": "^3.3.3",
         "yargs": "^17.7.2",
-        "zero-decimal-currencies": "^1.2.0"
+        "zero-decimal-currencies": "^1.6.0"
       },
       "bin": {
         "evershop": "dist/bin/evershop.js"
@@ -2662,6 +2663,16 @@
       },
       "engines": {
         "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@evershop/sonner": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@evershop/sonner/-/sonner-2.0.7.tgz",
+      "integrity": "sha512-mPYP55hqN1asPDZZRC1F10BXdHaW1tVBvhnIAdYikduNxQVZQNKqyeVUbtNJyVEiIQZ2QDz19z82lyfgYJGkmg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/@floating-ui/core": {
@@ -5056,25 +5067,28 @@
       }
     },
     "node_modules/@stripe/react-stripe-js": {
-      "version": "1.16.5",
-      "resolved": "https://registry.npmjs.org/@stripe/react-stripe-js/-/react-stripe-js-1.16.5.tgz",
-      "integrity": "sha512-lVPW3IfwdacyS22pP+nBB6/GNFRRhT/4jfgAK6T2guQmtzPwJV1DogiGGaBNhiKtSY18+yS8KlHSu+PvZNclvQ==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@stripe/react-stripe-js/-/react-stripe-js-3.10.0.tgz",
+      "integrity": "sha512-UPqHZwMwDzGSax0ZI7XlxR3tZSpgIiZdk3CiwjbTK978phwR/fFXeAXQcN/h8wTAjR4ZIAzdlI9DbOqJhuJdeg==",
       "license": "MIT",
       "dependencies": {
         "prop-types": "^15.7.2"
       },
       "peerDependencies": {
-        "@stripe/stripe-js": "^1.44.1",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+        "@stripe/stripe-js": ">=1.44.1 <8.0.0",
+        "react": ">=16.8.0 <20.0.0",
+        "react-dom": ">=16.8.0 <20.0.0"
       }
     },
     "node_modules/@stripe/stripe-js": {
-      "version": "1.54.2",
-      "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-1.54.2.tgz",
-      "integrity": "sha512-R1PwtDvUfs99cAjfuQ/WpwJ3c92+DAMy9xGApjqlWQMj0FKQabUAys2swfTRNzuYAYJh7NqK2dzcYVNkKLEKUg==",
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-5.10.0.tgz",
+      "integrity": "sha512-PTigkxMdMUP6B5ISS7jMqJAKhgrhZwjprDqR1eATtFfh0OpKVNp110xiH+goeVdrJ29/4LeZJR4FaHHWstsu0A==",
       "license": "MIT",
-      "peer": true
+      "peer": true,
+      "engines": {
+        "node": ">=12.16"
+      }
     },
     "node_modules/@swc/cli": {
       "version": "0.7.9",
@@ -5814,6 +5828,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.3.tgz",
       "integrity": "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -9555,9 +9570,9 @@
       }
     },
     "node_modules/immutable": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.0.3.tgz",
-      "integrity": "sha512-P8IdPQHq3lA1xVeBRi5VPqUm5HDgKnx0Ru51wZz5mjxHr5n3RWhjIpOFU7ybkUxfB+5IToy+OLaHYDBIWsv+uw==",
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.5.tgz",
+      "integrity": "sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==",
       "license": "MIT"
     },
     "node_modules/import-fresh": {
@@ -10615,18 +10630,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.6"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      }
-    },
     "node_modules/mlly": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.0.tgz",
@@ -10654,21 +10657,22 @@
       "license": "MIT"
     },
     "node_modules/multer": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/multer/-/multer-2.0.2.tgz",
-      "integrity": "sha512-u7f2xaZ/UG8oLXHvtF/oWTRvT44p9ecwBBqTwgJVq0+4BW1g8OW01TyMEGWBHbyMOYVHXslaut7qEQ1meATXgw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.1.1.tgz",
+      "integrity": "sha512-mo+QTzKlx8R7E5ylSXxWzGoXoZbOsRMpyitcht8By2KHvMbf3tjwosZ/Mu/XYU6UuJ3VZnODIrak5ZrPiPyB6A==",
       "license": "MIT",
       "dependencies": {
         "append-field": "^1.0.0",
         "busboy": "^1.6.0",
         "concat-stream": "^2.0.0",
-        "mkdirp": "^0.5.6",
-        "object-assign": "^4.1.1",
-        "type-is": "^1.6.18",
-        "xtend": "^4.0.2"
+        "type-is": "^1.6.18"
       },
       "engines": {
         "node": ">= 10.16.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/nanoid": {
@@ -12176,14 +12180,14 @@
       }
     },
     "node_modules/sass": {
-      "version": "1.83.0",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.83.0.tgz",
-      "integrity": "sha512-qsSxlayzoOjdvXMVLkzF84DJFc2HZEL/rFyGIKbbilYtAvlCxyuzUeff9LawTn4btVnLKg75Z8MMr1lxU1lfGw==",
+      "version": "1.99.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.99.0.tgz",
+      "integrity": "sha512-kgW13M54DUB7IsIRM5LvJkNlpH+WhMpooUcaWGFARkF1Tc82v9mIWkCbCYf+MBvpIUBSeSOTilpZjEPr2VYE6Q==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "chokidar": "^4.0.0",
-        "immutable": "^5.0.2",
+        "immutable": "^5.1.5",
         "source-map-js": ">=0.6.2 <2.0.0"
       },
       "bin": {
@@ -12816,16 +12820,20 @@
       "license": "MIT"
     },
     "node_modules/stripe": {
-      "version": "8.222.0",
-      "resolved": "https://registry.npmjs.org/stripe/-/stripe-8.222.0.tgz",
-      "integrity": "sha512-hrA79fjmN2Eb6K3kxkDzU4ODeVGGjXQsuVaAPSUro6I9MM3X+BvIsVqdphm3BXWfimAGFvUqWtPtHy25mICY1w==",
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-21.0.1.tgz",
+      "integrity": "sha512-ocv0j7dWttswDWV2XL/kb6+yiLpDXNXL3RQAOB5OB2kr49z0cEatdQc12+zP/j5nrXk6rAsT4N3y/NUvBbK7Pw==",
       "license": "MIT",
-      "dependencies": {
-        "@types/node": ">=8.1.0",
-        "qs": "^6.10.3"
-      },
       "engines": {
-        "node": "^8.1 || >=10.*"
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/strnum": {
@@ -14158,10 +14166,13 @@
       }
     },
     "node_modules/zero-decimal-currencies": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/zero-decimal-currencies/-/zero-decimal-currencies-1.2.0.tgz",
-      "integrity": "sha512-iZ0BuhUF7XacUpCrdx2Y+eAK5BUbw5bS7LrGQZ7/6R5Q16YF11DdyYU4bV7cAs2QxoAQ/LJcgNPbvZ7JTwi3qA==",
-      "license": "MIT"
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/zero-decimal-currencies/-/zero-decimal-currencies-1.6.0.tgz",
+      "integrity": "sha512-wKH71bIE1qxnKD+J4N+zTSqQpYN5Q4QTDPYAzq3DhwjwE6/62VhIXguRWJp+EW9EdOhqQV5sgY9C39eVvVhqcQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "description": "",
   "type": "module",
   "dependencies": {
-    "@evershop/evershop": "2.1.1",
+    "@evershop/evershop": "2.1.2",
     "@evershop/s3_file_storage": "2.1.1",
     "nodemailer": "^6.9.15"
   },


### PR DESCRIPTION
## Summary
- upgrade `@evershop/evershop` from `2.1.1` to `2.1.2`
- keep `@evershop/s3_file_storage` at `2.1.1` because `2.1.2` is not published
- refresh the lockfile

## Breaking change review
- checked the `2.1.2` release notes
- the release renames several PayPal/Stripe payment statuses
- searched this repo and found no local custom usage of the old status strings

## Verification
- `npm test` ✅ (1 file, 11 tests passed)
- `npm run build` ✅
