### PR TITLE
Fix homepage CTA target

### DIFF
--- a/themes/eve/src/pages/homepage/FeaturedCategories.tsx
+++ b/themes/eve/src/pages/homepage/FeaturedCategories.tsx
@@ -31,7 +31,7 @@ const CATEGORIES: CategoryItem[] = [
 
 const FeaturedCategories: React.FC = () => {
   return (
-    <section className="featured-categories">
+    <section id="featured-categories" className="featured-categories">
       <div className="page-width">
         <div className="featured-categories-header">
           <span className="featured-categories-label">Browse</span>

--- a/themes/eve/src/pages/homepage/MainBanner.tsx
+++ b/themes/eve/src/pages/homepage/MainBanner.tsx
@@ -19,8 +19,8 @@ const MainBanner: React.FC = () => {
               sure to deliver the perfect promotion for your business.
             </p>
             <div className="flex flex-col sm:flex-row gap-4 justify-center md:justify-start">
-              <a className="button button-primary" href="/products">
-                SHOP NOW
+              <a className="button button-primary" href="/#featured-categories">
+                BROWSE CATEGORIES
               </a>
               <a className="button button-outline" href="/contact">
                 GET A QUOTE


### PR DESCRIPTION
## Summary
- replace the broken homepage hero CTA that pointed to \/products
- send the primary CTA to the featured categories section on the homepage
- update the CTA label to better match the destination

## Verification
- npm run build:theme:eve